### PR TITLE
[ENH] add pyafq support directly

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -31,6 +31,7 @@ install_requires =
     scipy==1.14.0
     PyGithub>=1.32
     GitPython==3.1.43
+    pyAFQ>=1.3.5
 
 zip_safe = False
 include_package_data = True


### PR DESCRIPTION
Previously, pyAFQ generated a folder that AFQ-browser could read.

With this, AFQ-browser will read pyAFQ outputs